### PR TITLE
Allow to provide development language along input files

### DIFF
--- a/Sources/rswift/App.swift
+++ b/Sources/rswift/App.swift
@@ -49,6 +49,9 @@ struct GlobalOptions: ParsableArguments {
     @Option(help: "Paths of files for which resources should be generated")
     var inputFiles: [String] = []
 
+    @Option(help: "The development region for the provided input files (i.e. \"en\"")
+    var developmentRegion: String?
+
     @Option(help: "Source of default bundle to use")
     var bundleSource: BundleSource = .finder
 
@@ -120,7 +123,7 @@ extension App {
                     try core.generateFromXcodeproj(url: xcodeprojURL, targetName: targetName)
 
                 case .inputFiles:
-                    try core.generateFromFiles(inputFileURLs: globals.inputFiles.map(URL.init(fileURLWithPath:)))
+                    try core.generateFromFiles(inputFileURLs: globals.inputFiles.map(URL.init(fileURLWithPath:)), developmentRegion: globals.developmentRegion)
                 }
             } catch let error as ResourceParsingError {
                 throw ValidationError(error.description)

--- a/Sources/rswift/RswiftCore.swift
+++ b/Sources/rswift/RswiftCore.swift
@@ -89,7 +89,7 @@ public struct RswiftCore {
         try generateFromProjectResources(resources: resources, developmentRegion: xcodeproj.developmentRegion, knownAssetTags: xcodeproj.knownAssetTags)
     }
 
-    public func generateFromFiles(inputFileURLs urls: [URL]) throws {
+    public func generateFromFiles(inputFileURLs urls: [URL], developmentRegion: String?) throws {
         let warning: (String) -> Void = { print("warning: [R.swift]", $0) }
 
         let resources = try ProjectResources.parseURLs(
@@ -102,7 +102,7 @@ public struct RswiftCore {
             warning: warning
         )
 
-        try generateFromProjectResources(resources: resources, developmentRegion: nil, knownAssetTags: nil)
+        try generateFromProjectResources(resources: resources, developmentRegion: developmentRegion, knownAssetTags: nil)
     }
 
     private func generateFromProjectResources(resources: ProjectResources, developmentRegion: String?, knownAssetTags: [String]?) throws {


### PR DESCRIPTION
Allow to provide development region along input files:
* Fixes the fallback to development region value when a string resource is not available for user's locale
* Avoids generating a resource if no value is available for development region